### PR TITLE
Do not highlight windows based on mouse if user is currently typing

### DIFF
--- a/src/effects/presentwindows/presentwindows.cpp
+++ b/src/effects/presentwindows/presentwindows.cpp
@@ -633,7 +633,9 @@ void PresentWindowsEffect::inputEventUpdate(const QPoint &pos, QEvent::Type type
     }
 
     if (!hovering)
-        setHighlightedWindow(nullptr);
+	if(m_windowFilter.isEmpty()){
+            setHighlightedWindow(nullptr);
+	}
     if (m_highlightedWindow && m_motionManager.transformedGeometry(m_highlightedWindow).contains(pos))
         updateCloseWindow();
     else if (m_closeView)
@@ -669,7 +671,7 @@ void PresentWindowsEffect::inputEventUpdate(const QPoint &pos, QEvent::Type type
                 mouseActionDesktop(m_rightButtonDesktop);
             }
         }
-    } else if (highlightCandidate && !m_motionManager.areWindowsMoving())
+    } else if (highlightCandidate && !m_motionManager.areWindowsMoving() && m_windowFilter.isEmpty())
         setHighlightedWindow(highlightCandidate);
 }
 
@@ -829,6 +831,7 @@ void PresentWindowsEffect::grabbedKeyboardEvent(QKeyEvent *e)
             break;
         case Qt::Key_Backspace:
             if (!m_windowFilter.isEmpty()) {
+		setHighlightedWindow(nullptr);
                 m_windowFilter.remove(m_windowFilter.length() - 1, 1);
                 updateFilterFrame();
                 rearrangeWindows();


### PR DESCRIPTION
If the user is currently typing, do not highlight windows based on the mouse position. If the user types a window title before the effect opening animation is finished, he ends up in a situation where only one window is on the screen but it is deselected (because the mouse is not on the window). 
With this change, the mouse input does not overwrite the window highlighting based on the search entered if the user is currently typing.