### PR TITLE
change RollOverDesktops to "false"

### DIFF
--- a/src/kwin.kcfg
+++ b/src/kwin.kcfg
@@ -103,7 +103,7 @@
             <default>true</default>
         </entry>
         <entry name="RollOverDesktops" type="Bool">
-            <default>true</default>
+            <default>false</default>
         </entry>
         <entry name="FocusStealingPreventionLevel" type="Int">
             <default>1</default>


### PR DESCRIPTION
QOL & Parity with the default "pager" applet for desktop navigation.

Reasoning: 
This setting is best used by advanced users, (more than 2-3 desktops), who can easily find and set it to their liking.
A new user will likely find this setting slightly confusing and hard to use, and may get put off multiple desktops.