### PR TITLE
screencast: Fixes bug 469777

### DIFF
--- a/src/plugins/screencast/screencaststream.h
+++ b/src/plugins/screencast/screencaststream.h
@@ -12,12 +12,10 @@
 
 #include "wayland/screencast_v1.h"
 
-#include <QDateTime>
 #include <QHash>
 #include <QObject>
 #include <QRegion>
 #include <QSocketNotifier>
-#include <QTimer>
 #include <chrono>
 #include <memory>
 #include <optional>
@@ -143,10 +141,6 @@ private:
     bool m_hasDmaBuf = false;
     bool m_waitForNewBuffers = false;
     quint32 m_drmFormat = 0;
-
-    QDateTime m_lastSent;
-    QRegion m_pendingDamages;
-    QTimer m_pendingFrame;
 };
 
 } // namespace KWin


### PR DESCRIPTION
Reverting commit cd5d67 to fix bug 469777.

Commit being reverted:
Author: Aleix Pol <[aleixpol@kde.org](mailto:aleixpol@kde.org)>
Date:   Thu Apr 6 20:28:40 2023 +0200

    screencast: Ensure we respect the negotiated framerate
    
    Discards frames sent under the timeframe that was negotiated with the
    client. This allows clients to just request the frames that they should
    be able to compute.

Reverting this commit fixes:
https://bugs.kde.org/show_bug.cgi?id=469777
